### PR TITLE
Fix codecept settings

### DIFF
--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -12,15 +12,13 @@ exports.config = {
       seleniumAddress: undefined,
       useAllAngular2AppRoots: true,
       smartWait: 5000,
-    }
-  },
-  include: {
-    I: './e2e/step_file.js'
-  },
-  helpers: {
+    },
     MyHelper: {
       require: './e2e/helpers/my_helper.ts',
     },
+  },
+  include: {
+    I: './e2e/step_file.js'
   },
   bootstrap: null,
   mocha: {},

--- a/e2e/helpers/my_helper.ts
+++ b/e2e/helpers/my_helper.ts
@@ -1,6 +1,6 @@
 import { AzureVaultService } from '../services/azureServices/azureVaultService';
 
-export class MyHelper extends Helper {
+class MyHelper extends Helper {
 
   async getNonProdPassword(): Promise<string> {
     const azureVault: AzureVaultService = new AzureVaultService();
@@ -9,3 +9,9 @@ export class MyHelper extends Helper {
   }
 
 }
+
+// use this variant
+module.exports = MyHelper;
+
+// or this variant, directly in declaration:
+// module.exports = class MyHelper extends Helper {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
      "outDir": "tsc-out", 
-      "target": "es5",
+      "target": "es2017",
       "moduleResolution": "node",
       "module": "commonjs",
       "lib": [


### PR DESCRIPTION
Found 3 possible problems.
That's not absolute true, I am not an all-known typescript developer. But this helps me to run codecept with ts-node.
There are may be the better solution. Speak with some ts developers, maybe they'll help.

1. **TL;DR;** use `target: "es2017"` in tsconfig.
<br>**Long:**
First of all you use `target: "es5"` in tsconfig.
But codecept require `async`/`await` constructions and a few other components from modern ECMA Script. 
If you look on codecept's "quickstart" https://codecept.io/quickstart , you see `NodeJS v 8.9 and higher required to start`.
If you look for `async`/`await` in standards, you see it appears in "ES2017". (for example https://flaviocopes.com/es2017/)
<br>That's mean you should write according ES2017 standard.
Or, in your case, as typescript is used. It should compile to ES2017:
```
{
    "compilerOptions": {
      "target": "es2017",
      ...
```

2. **TL;DR;** Use `module.exports` instead of `exports`
<br>**Long:**
Second problem:
codecept for helper's nodule resolution uses next construction:
```
// helperName - name of helper, described in `helpers` section of codecept config
// moduleName - file path, based on described in `require` attribute of this helper object in codecept config
...
   // A. requiring
  const HelperClass = require(moduleName);
...
  // B. initializing
  helpers[helperName] = new HelperClass(config[helperName]);
...
```

On B, codecept tries create class, required from this module.
<br>
When you use `module.exports = Helper` , the module for export looks like this class only. So, you initialize the Class, you imported.
<br>
When you use `export class Helper` , module exports object with attribute with name of class, that equal to this class. It looks like: `{ Helper: <Helper class object> }` .
<br>Codecept tries to initialize object `{ Helper }`, but it just object, not class - it has not constructor. Error occurs.
`export default class Helper` also does not help, cause it create object with `default` name: `{ default: <Helper class object> }`. It's the same error.
<br>
So use:
```
class MyHelper extends Helper {
...
module.exports = MyHelper;
```
or
```
module.exports = class MyHelper extends Helper {
...
```

3. **TL;DR;** In config use one `helper` object
<br>**Long:**
You used
```
exports.config = {
...
  helpers: {
    Protractor: {
...
    }
  },
...
  helpers: {
    MyHelper: {
      require: './e2e/helpers/my_helper.ts',
    },
  },
...
}
```
Double definition in one object not works - second will rewrite first.
So Protractor is not available in test run
<br>
Use one place description:
```
exports.config = {
...
  helpers: {
    Protractor: {
...
    },
    MyHelper: {
      require: './e2e/helpers/my_helper.ts',
    },
  },
...
}
```
Or append later:
```
exports.config = {
...
  helpers: {
    Protractor: {
...
    },
  },
...
}

exports.config.helpers.MyHelper {
  require: './e2e/helpers/my_helper.ts',
},
```